### PR TITLE
Adding logic to parser for duplicate accessions

### DIFF
--- a/ncbi-datasets-parser.py
+++ b/ncbi-datasets-parser.py
@@ -37,7 +37,22 @@ def filter_genomes(jsonl_file) -> list:
             # check total count for strain and add to output list if under 2
             # TODO: no duplicate accession numbers  (one from RefSeq, one from GenBank)
                 # add accession number to set
-                # adjust logic below to only consider strain if the accession number is not in the set 
+                # adjust logic below to only consider strain if the accession number is not in the set
+            
+            #This is the set that is going to have the unique accessions
+            unique_accessions = set()
+
+            #Input: "GCF_0001.0", "GCA_0001.0" then the output is going to be "00010". I originally wanted it to look like
+            # "0001.0" but really the '.' doesn't have a purpose; at least I do not think that it does. Not if there is a duplicate
+            # the program will only have the unique accessions in unique_accessions
+            for accession in accesions:
+                numeric_acession = ''
+                for char in accession:
+                    if char.isdigit():
+                        numeric_acession += char
+                if numeric_acession not in unique_accessions:
+                    unique_accessions.add(numeric_acession)
+
             if strain in strain_count_dict:
                 if strain_count_dict[strain] < 2:
                     filtered_list.append((strain, accesion_ID, taxid))

--- a/ncbi-datasets-parser.py
+++ b/ncbi-datasets-parser.py
@@ -39,7 +39,7 @@ def filter_genomes(jsonl_file) -> list:
                 # add accession number to set
                 # adjust logic below to only consider strain if the accession number is not in the set
             
-            #This is the set that is going to have the unique accessions
+            #This is the set that is going to have the unique accessions.
             unique_accessions = set()
 
             #Input: "GCF_0001.0", "GCA_0001.0" then the output is going to be "00010". I originally wanted it to look like


### PR DESCRIPTION
Adding logic to the parser that removes duplicate accessions. Removes all of the characters that are not numbers, if there are duplicates then it removes them leaving only one accession. 